### PR TITLE
Compatibility with BuddyPress Group Forum Replies

### DIFF
--- a/bbp-private-replies.php
+++ b/bbp-private-replies.php
@@ -26,7 +26,7 @@ class BBP_Private_Replies {
 		add_action( 'init', array( $this, 'textdomain' ) );
 
 		// show the "Private Reply?" checkbox
-		add_action( 'bbp_theme_before_reply_form_subscription', array( $this, 'checkbox' ) );
+		add_action( 'bbp_theme_before_reply_form_submit_wrapper', array( $this, 'checkbox' ) );
 
 		// save the private reply state
 		add_action( 'bbp_new_reply',  array( $this, 'update_reply' ), 0, 6 );


### PR DESCRIPTION
We are using buddypress-group level forums. 

Private checkbox wasn't appearing there. I changed hook and its working fine with bbPress/BuddyPress.

Thanks for your plugin. :-)
