### PR TITLE
Add a new "moderator-only" replies feature. 

### DIFF
--- a/bbp-private-replies.php
+++ b/bbp-private-replies.php
@@ -3,7 +3,7 @@
 Plugin Name: bbPress - Private Replies - Enhanced
 Plugin URL: https://github.com/DavidAnderson684/bbpress-private-replies-enhanced
 Description: Allows users to set replies as private so that only the original poster and admins can see it
-Version: 1.5.0
+Version: 1.5.1
 Author: Pippin Williamson, Remi Corson, David Anderson
 Author URI: https://david.dw-perspective.org.uk
 Contributors: mordauk, corsonr, DavidAnderson
@@ -492,6 +492,7 @@ class BBP_Private_Replies {
 	 */
 	public function delete_private_replies_daily() {
 		
+		if (!apply_filters( 'bbp_private_replies_delete_private_replies_daily', true )) return;
 		
 		$args = apply_filters( 'bbp_private_replies_is_private_query_args', array(
 				'post_type' => 'reply',

--- a/bbp-private-replies.php
+++ b/bbp-private-replies.php
@@ -3,7 +3,7 @@
 Plugin Name: bbPress - Private Replies - Enhanced
 Plugin URL: https://github.com/DavidAnderson684/bbpress-private-replies-enhanced
 Description: Allows users to set replies as private so that only the original poster and admins can see it
-Version: 1.4.0
+Version: 1.4.1
 Author: Pippin Williamson, Remi Corson, David Anderson
 Author URI: https://david.dw-perspective.org.uk
 Contributors: mordauk, corsonr, DavidAnderson

--- a/bbp-private-replies.php
+++ b/bbp-private-replies.php
@@ -1,13 +1,13 @@
 <?php
 /*
-Plugin Name: bbPress - Private Replies
-Plugin URL: http://pippinsplugins.com/bbpress-private-replies
+Plugin Name: bbPress - Private Replies - Enhanced
+Plugin URL: https://github.com/DavidAnderson684/bbpress-private-replies-enhanced
 Description: Allows users to set replies as private so that only the original poster and admins can see it
 Version: 1.4.0
 Author: Pippin Williamson, Remi Corson, David Anderson
-Author URI: http://pippinsplugins.com
+Author URI: https://david.dw-perspective.org.uk
 Contributors: mordauk, corsonr, DavidAnderson
-Text Domain: bbp_private_replies
+Text Domain: bbpress-private-replies-enhanced
 Domain Path: languages
 */
 
@@ -81,7 +81,7 @@ class BBP_Private_Replies {
 	 * @return void
 	 */
 	public function textdomain() {
-		load_plugin_textdomain( 'bbp_private_replies', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+		load_plugin_textdomain( 'bbpress-private-replies-enhanced', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 	}
 
 	/**
@@ -280,7 +280,7 @@ class BBP_Private_Replies {
 			}
 
 			if( ! $can_view ) {
-				$content = __( 'This reply has been marked as moderator-only.', 'bbp_private_replies' );
+				$content = __( 'This reply has been marked as moderator-only.', 'bbpress-private-replies-enhanced' );
 			}
 
 		} elseif ( $this->is_private( $reply_id ) ) {
@@ -306,7 +306,7 @@ class BBP_Private_Replies {
 			}
 
 			if( ! $can_view ) {
-				$content = __( 'This reply has been marked as private.', 'bbp_private_replies' );
+				$content = __( 'This reply has been marked as private.', 'bbpress-private-replies-enhanced' );
 			}
 		}
 

--- a/css/frond-end.css
+++ b/css/frond-end.css
@@ -11,5 +11,5 @@
 }
 
 .topic .bbp-moderator-only-reply.is-moderator {
-	background: #78C0EC !important;
+	background: #FFC107 !important;
 }

--- a/css/frond-end.css
+++ b/css/frond-end.css
@@ -5,3 +5,11 @@
 .topic .bbp-private-reply {
 	background: #78C0EC !important;
 }
+
+.topic .bbp-moderator-only-reply.not-moderator {
+	display: none !important;
+}
+
+.topic .bbp-moderator-only-reply.is-moderator {
+	background: #78C0EC !important;
+}

--- a/languages/bbp_private_replies.pot
+++ b/languages/bbp_private_replies.pot
@@ -1,30 +1,48 @@
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: bbPress Private Replies\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-11-16 09:52+0100\n"
+"POT-Creation-Date: 2020-12-04 20:25+0530\n"
 "PO-Revision-Date: 2012-11-16 10:04+0100\n"
 "Last-Translator: FxB <fx@fxbenard.com>\n"
-"Language-Team: Pippin's Plugins, Rémi Corson <pippin@pippinsplugins.com>\n"
+"Language-Team: Pippin's Plugins, Rémi Corson <pippin@pippinsplugins."
+"com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-KeywordsList: __;_e;_x;_n;esc_attr__;esc_attr_e;esc_html__;"
 "esc_html_e;_ex:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2;_x:1,2c;_n:1,2\n"
-"X-Poedit-Basepath: ../\n"
+"X-Poedit-Basepath: ..\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 2.4.2\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: bbp-private-replies.php:77
+#: bbp-private-replies.php:134
 msgid "Set author's post as private."
 msgstr ""
 
-#: bbp-private-replies.php:81
+#: bbp-private-replies.php:138
 msgid "Set as private reply"
 msgstr ""
 
-#: bbp-private-replies.php:168
+#: bbp-private-replies.php:152
+msgid "Set author's post as moderator-only."
+msgstr ""
+
+#: bbp-private-replies.php:156
+msgid "Set as moderator-only reply"
+msgstr ""
+
+#: bbp-private-replies.php:291
+msgid "This reply has been marked as moderator-only."
+msgstr ""
+
+#: bbp-private-replies.php:317
 msgid "This reply has been marked as private."
+msgstr ""
+
+#: bbp-private-replies.php:522
+msgid "Private reply automatically removed after 3 months."
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
-=== bbPress - Private Replies ===
-Author URI: http://pippinsplugins.com
-Plugin URI: http://pippinsplugins.com/bbpress-private-replies
-Contributors: mordauk, corsonr
-Donate link: http://pippinsplugins.com/support-the-site
-Tags: bbPress, private replies, replies, Forums, mordauk, Pippin Williamson, pippinsplugins, Remi Corson, corsonr
-Requires at least: 3.2
-Tested up to: 5.1
+=== bbPress - Private Replies - Enhanced ===
+Author URI: https://david.dw-perspective.org.uk
+Plugin URI: https://github.com/DavidAnderson684/bbpress-private-replies-enhanced
+Contributors: mordauk, corsonr, DavidAnderson
+Donate link: https://david.dw-perspective.org.uk/donate
+Tags: bbPress, private replies, replies, Forums
+Requires at least: 4.9
+Tested up to: 5.2
 Stable Tag: 1.4.0
 
 A simple plugin to allow your bbPress users to mark their replies as private (visible only to the user and moderators), or moderator-only.
@@ -42,6 +42,12 @@ Would you like to help translate the plugin into more languages? [Contact Pippin
 
 
 == Changelog ==
+
+= 1.4.1 - 03/May/2019 =
+
+* Make text domain agree with plugin slug
+* Change plugin slug to bbpress-private-replies-enhanced
+* Mark as requiring WP 4.9+. Likely works very much earlier, but nothing earlier will receive support.
 
 = 1.4.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: https://david.dw-perspective.org.uk/donate
 Tags: bbPress, private replies, replies, Forums
 Requires at least: 4.9
 Tested up to: 5.2
-Stable Tag: 1.4.0
+Stable Tag: 1.4.1
 
 A simple plugin to allow your bbPress users to mark their replies as private (visible only to the user and moderators), or moderator-only.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,14 +5,14 @@ Contributors: mordauk, corsonr
 Donate link: http://pippinsplugins.com/support-the-site
 Tags: bbPress, private replies, replies, Forums, mordauk, Pippin Williamson, pippinsplugins, Remi Corson, corsonr
 Requires at least: 3.2
-Tested up to: 4.7
-Stable Tag: 1.3.3
+Tested up to: 5.1
+Stable Tag: 1.4.0
 
-A simple plugin to allow your bbPress users to mark their replies as private.
+A simple plugin to allow your bbPress users to mark their replies as private (visible only to the user and moderators), or moderator-only.
 
 == Description ==
 
-This add-on plugin for bbPress will allow your forum posters to mark their replies as private, meaning that only the original poster and forum moderators can see the content of the reply. This is a great plugin to install if you use bbPress as a support forum where users may need to share confidential information, such as site URLs, passwords, etc.
+This add-on plugin for bbPress will allow your forum posters to mark their replies as private, meaning that only the original poster and forum moderators can see the content of the reply; or as moderator-only. This is a great plugin to install if you use bbPress as a support forum where users may need to share confidential information, such as site URLs, passwords, etc., or where moderators want to share information that is not visible to other users.
 
 If you have suggestions or bugfixes for the plugin, please report them on [Github](https://github.com/pippinsplugins/bbPress-Private-replies).
 
@@ -42,6 +42,10 @@ Would you like to help translate the plugin into more languages? [Contact Pippin
 
 
 == Changelog ==
+
+= 1.4.0 =
+
+* Add a new "moderator-only" replies feature. These differ from "private replies" in that they are also hidden from the topic poster (unless they are a moderator)
 
 = 1.3.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Contributors: mordauk, corsonr, DavidAnderson
 Donate link: https://david.dw-perspective.org.uk/donate
 Tags: bbPress, private replies, replies, Forums
 Requires at least: 4.9
-Tested up to: 5.2
-Stable Tag: 1.4.1
+Tested up to: 5.5.3
+Stable Tag: 1.5.0
 
 A simple plugin to allow your bbPress users to mark their replies as private (visible only to the user and moderators), or moderator-only.
 
@@ -42,6 +42,10 @@ Would you like to help translate the plugin into more languages? [Contact Pippin
 
 
 == Changelog ==
+
+= 1.5.0 - 04/Dec/2020 =
+
+* Added daily cron scheduler for replace older than 3 months private replies with generic "deleted" message 
 
 = 1.4.1 - 03/May/2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: mordauk, corsonr, DavidAnderson
 Donate link: https://david.dw-perspective.org.uk/donate
 Tags: bbPress, private replies, replies, Forums
 Requires at least: 4.9
-Tested up to: 5.5.3
+Tested up to: 5.6
 Stable Tag: 1.5.0
 
 A simple plugin to allow your bbPress users to mark their replies as private (visible only to the user and moderators), or moderator-only.

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: https://david.dw-perspective.org.uk/donate
 Tags: bbPress, private replies, replies, Forums
 Requires at least: 4.9
 Tested up to: 5.6
-Stable Tag: 1.5.0
+Stable Tag: 1.5.1
 
 A simple plugin to allow your bbPress users to mark their replies as private (visible only to the user and moderators), or moderator-only.
 
@@ -42,6 +42,10 @@ Would you like to help translate the plugin into more languages? [Contact Pippin
 
 
 == Changelog ==
+
+= 1.5.1 - 15/Dec/2020 =
+
+* TWEAK: Introduce filter bbp_private_replies_delete_private_replies_daily to allow disabling of automatic deleting of private messages
 
 = 1.5.0 - 04/Dec/2020 =
 


### PR DESCRIPTION
These differ from "private replies" in that they are also hidden from the topic poster (unless they are a moderator).

They differ from the notes provided by the "bbpress admin notes" plugin in that the replies are still replies, i.e. full posts, and can thus benefit from any capabilities of replies (e.g. post HTML).